### PR TITLE
check if nextSibling exists before wrapping

### DIFF
--- a/IMDb_Scout_Mod.user.js
+++ b/IMDb_Scout_Mod.user.js
@@ -7840,7 +7840,10 @@ function performPage() {
     is_tv    = false;
     is_movie = false;
   }
-  if (!onReferencePage && !$('[property="og:title"]').length || onReferencePage && !$('li.ipl-inline-list__item').length) {
+  if (
+    (!onReferencePage && !$('[property="og:title"]').length) ||
+    (onReferencePage && !$('li.ipc-inline-list__item').length)
+  ) {
     console.log("IMDb Scout Mod (Get a genre Error): Element not found! Please report it.");
     GM.notification("Element not found! Please report it.", "IMDb Scout Mod (Get a genre Error)");
   }

--- a/IMDb_Scout_Mod.user.js
+++ b/IMDb_Scout_Mod.user.js
@@ -7468,8 +7468,11 @@ function addIconBar(movie_id, movie_title, movie_title_orig) {
   // reference + remove "Reference View" txt and a link to settings
   if ($('.titlereference-header div script').length) {
     // wrap text node for removal
-    $($('.titlereference-header div script')[0].nextSibling).wrap('<span class="removethis"/>');
-    $('.removethis').remove();
+    var scriptElem = $('.titlereference-header div script')[0];
+    if (scriptElem && scriptElem.nextSibling) {
+      $(scriptElem.nextSibling).wrap('<span class="removethis"/>');
+      $('.removethis').remove();
+    }
     $('.titlereference-change-view-link').remove();
     iconbar = getIconsLinkArea();
   // in case if code above breaks
@@ -7815,7 +7818,12 @@ function performPage() {
     // reference
     const m = $('h3[itemprop="name"]').text().trim();
     movie_title = m.split('\n')[0].trim();
-    movie_title_orig = $.trim($($('h3[itemprop="name"]')[0].nextSibling).text());
+    var h3Elem = $('h3[itemprop="name"]')[0];
+    if (h3Elem && h3Elem.nextSibling) {
+      movie_title_orig = $.trim($(h3Elem.nextSibling).text());
+    } else {
+      movie_title_orig = movie_title;
+    }
     // movie_title_orig not found
     if (movie_title_orig === "" || movie_title_orig === undefined) {
       movie_title_orig = movie_title;


### PR DESCRIPTION
This seems to get reference view working on Edge. There's still `IMDb Scout Mod (Get a genre Error): Element not found! Please report it.`
![Screenshot 2025-06-14 104450](https://github.com/user-attachments/assets/c2ad67ea-d495-417f-8f0d-bd2732f02f99)
