### PR TITLE
refactor: replace eval() with Array.reduce() for rating sum

### DIFF
--- a/IMDb_Scout_Mod.user.js
+++ b/IMDb_Scout_Mod.user.js
@@ -10560,7 +10560,7 @@ function getLetterboxdRatingsCustom(url, lboxd_cust) {
         ratings_array.push($(result).find('.rated-large-10').parentsUntil('.section').find('li').length *10);
 
         const voters = $(result).find('.film-rating-group').find('li').length;
-        const average = (eval(ratings_array.join("+")) / voters) *10;
+        const average = (ratings_array.reduce((a, b) => a + b, 0) / voters) *10;
         user_rating = Math.round(average);
       } else {
         return;


### PR DESCRIPTION
The Letterboxd custom-average calculation at line 10563 uses `eval(ratings_array.join("+"))` to sum an array of numbers. Equivalent via `reduce`, without eval — CSP-safer, no perf loss.

Before:
```js
const average = (eval(ratings_array.join("+")) / voters) *10;
```

After:
```js
const average = (ratings_array.reduce((a, b) => a + b, 0) / voters) *10;
```

Thanks for the great work on IMDb-Scout-Mod!